### PR TITLE
Fix new helm-unittest tests

### DIFF
--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-configmap-addheaders_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-configmap-addheaders_test.yaml
@@ -21,7 +21,7 @@ tests:
           of: ConfigMap
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-custom-add-headers
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-custom-add-headers
       - equal:
           path: data.X-Another-Custom-Header
           value: Value

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-configmap-proxyheaders_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-configmap-proxyheaders_test.yaml
@@ -21,7 +21,7 @@ tests:
           of: ConfigMap
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-custom-proxy-headers
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-custom-proxy-headers
       - equal:
           path: data.X-Custom-Header
           value: Value

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-configmap_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-configmap_test.yaml
@@ -11,4 +11,4 @@ tests:
           of: ConfigMap
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-daemonset_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-daemonset_test.yaml
@@ -13,4 +13,4 @@ tests:
           of: DaemonSet
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-daemonset_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-daemonset_test.yaml
@@ -6,6 +6,7 @@ tests:
   - it: should create a DaemonSet if `controller.kind` is "DaemonSet"
     set:
       controller.kind: DaemonSet
+      kind: Vanilla
     asserts:
       - hasDocuments:
           count: 1

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-deployment_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-deployment_test.yaml
@@ -11,7 +11,7 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller
 
   - it: should create a Deployment with 3 replicas if `controller.replicaCount` is 3
     set:

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-deployment_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-deployment_test.yaml
@@ -4,6 +4,8 @@ templates:
 
 tests:
   - it: should create a Deployment
+    set:
+      kind: Vanilla
     asserts:
       - hasDocuments:
           count: 1
@@ -16,6 +18,7 @@ tests:
   - it: should create a Deployment with 3 replicas if `controller.replicaCount` is 3
     set:
       controller.replicaCount: 3
+      kind: Vanilla
     asserts:
       - equal:
           path: spec.replicas
@@ -25,6 +28,7 @@ tests:
     set:
       controller.resources.limits.cpu: 500m
       controller.resources.limits.memory: 512Mi
+      kind: Vanilla
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-hpa_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-hpa_test.yaml
@@ -14,4 +14,4 @@ tests:
           of: HorizontalPodAutoscaler
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-keda_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-keda_test.yaml
@@ -14,4 +14,4 @@ tests:
           of: ScaledObject
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-networkpolicy_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-networkpolicy_test.yaml
@@ -20,4 +20,4 @@ tests:
           of: NetworkPolicy
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-service-internal_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-service-internal_test.yaml
@@ -22,4 +22,4 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller-internal
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller-internal

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-service-metrics_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-service-metrics_test.yaml
@@ -20,4 +20,4 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller-metrics
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller-metrics

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-service_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/controller-service_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-controller
 
   - it: should create a Service of type "NodePort" if `controller.service.external.enabled` is true and `controller.service.type` is "NodePort"
     set:

--- a/build_system/charts/open-appsec-k8s-nginx-ingress/tests/default-backend-service_test.yaml
+++ b/build_system/charts/open-appsec-k8s-nginx-ingress/tests/default-backend-service_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-defaultbackend
+          value: RELEASE-NAME-open-appsec-k8s-nginx-ingress-defaultbackend
 
   - it: should create a Service with port 80 if `defaultBackend.service.port` is 80
     set:


### PR DESCRIPTION
Good day,

Noticed that the latest sync from the upstream [ingress-nginx](https://github.com/kubernetes/ingress-nginx) included [helm-unittests](https://github.com/helm-unittest/helm-unittest) that were broken. 

## Fix
To resolve these issues, I made the following changes:
- I added set to `Vanilla` for `Values.kind` in the requested tests, [controller-deployment_test.yaml](https://github.com/openappsec/openappsec/compare/main...bmbeverst:openappsec:fix_tests?expand=1#diff-00cca53b19627a269eb7bf12559127d1a5cff5cbca36f102bd4086e8f6983aa2) and [controller-daemonset_test.yaml](https://github.com/openappsec/openappsec/compare/main...bmbeverst:openappsec:fix_tests?expand=1#diff-fad7fcdc51d906aeec0d98b7595564cea94a6a40c12b784780a2150214be1791).
- I also changed the names from `ingress-nginx` to `open-appsec-k8s-nginx-ingress` as needed.

## Recommendations
To make this easier in the future, it should be automated. I know that the change from `ingress-nginx` to `open-appsec-k8s-nginx-ingress`  can re automated.  For example, `sed -i 's/ingress-nginx/open-appsec-k8s-nginx-ingress/g' tests/*`. But setting `Values.kind` to `Vanilla` will be harder. There are two cases to handle, one when the `set:` already exists and another where it does not. 


## helm unittest results:
After the changes, the unittest passed.
```
> helm unittest ./

### Chart [ open-appsec-k8s-nginx-ingress ] ./

 PASS  Controller > ConfigMap > Add Headers	tests/controller-configmap-addheaders_test.yaml
 PASS  Controller > ConfigMap > Proxy Headers	tests/controller-configmap-proxyheaders_test.yaml
 PASS  Controller > ConfigMap	tests/controller-configmap_test.yaml
 PASS  Controller > DaemonSet	tests/controller-daemonset_test.yaml
 PASS  Controller > Deployment	tests/controller-deployment_test.yaml
 PASS  Controller > HPA	tests/controller-hpa_test.yaml
 PASS  Controller > KEDA	tests/controller-keda_test.yaml
 PASS  Controller > NetworkPolicy	tests/controller-networkpolicy_test.yaml
 PASS  Controller > Service > Internal	tests/controller-service-internal_test.yaml
 PASS  Controller > Service > Metrics	tests/controller-service-metrics_test.yaml
 PASS  Controller > Service	tests/controller-service_test.yaml
 PASS  Default Backend > Extra ConfigMaps	tests/default-backend-extra-configmaps_test.yaml
 PASS  Default Backend > Service	tests/default-backend-service_test.yaml

Charts:      1 passed, 1 total
Test Suites: 13 passed, 13 total
Tests:       26 passed, 26 total
Snapshot:    0 passed, 0 total
Time:        396.437958ms
```