### PR TITLE
Disabled return to line for threat prevention logs

### DIFF
--- a/core/include/services_sdk/resources/report/base_field.h
+++ b/core/include/services_sdk/resources/report/base_field.h
@@ -120,8 +120,6 @@ class LogField : Singleton::Consume<I_Environment>
                         break;
                     }
                     case '\n': {
-                        encoded_value.push_back('\\');
-                        encoded_value.push_back('n');
                         break;
                     }
                     case '\r': {


### PR DESCRIPTION
Related to issue [https://github.com/openappsec/openappsec/issues/154](https://github.com/openappsec/openappsec/issues/154) as return to line breaks the ability of filtering the logs as one-line not multiple in stdout and Cloud Logging for example.