### PR TITLE
Fixing Incorrect early exits

### DIFF
--- a/components/security_apps/rate_limit/rate_limit.cc
+++ b/components/security_apps/rate_limit/rate_limit.cc
@@ -185,7 +185,7 @@ public:
         ScopedContext rate_limit_ctx;
         rate_limit_ctx.registerValue<GenericConfigId>(AssetMatcher::ctx_key, site_config->get_AssetId());
         auto maybe_rate_limit_config = getConfiguration<RateLimitConfig>("rulebase", "rateLimit");
-        if (!maybe_rate_limit_config.ok())
+        if (!maybe_rate_limit_config.ok() || !site_config)
             return genError("Failed to get rate limit configuration. Skipping rate limit check.");
 
         const auto &rate_limit_config = maybe_rate_limit_config.unpack();


### PR DESCRIPTION
if this fails (maybe_rate_limit_config.ok() is false), rate_limit_config.getRateLimitMode() will be undefined behavior.