### PR TITLE
update PostgreSQL configuration in deployment files

### DIFF
--- a/deployment/docker-compose/apisix/.env
+++ b/deployment/docker-compose/apisix/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Make sure to have a valid apisix configuration for APISIX in standalone mode in the following file:
 ## For deployment of a simple lab testing environment, you can deploy the example configuration provided

--- a/deployment/docker-compose/apisix/docker-compose.yaml
+++ b/deployment/docker-compose/apisix/docker-compose.yaml
@@ -103,14 +103,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: always
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/envoy/.env
+++ b/deployment/docker-compose/envoy/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Make sure to have a valid envoy.yaml Envoy configuration file present in the path below.
 ## For deployment of a simple lab testing environment, you can deploy the example configuration provided

--- a/deployment/docker-compose/envoy/docker-compose.yaml
+++ b/deployment/docker-compose/envoy/docker-compose.yaml
@@ -109,14 +109,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/kong-lua-plugin/.env
+++ b/deployment/docker-compose/kong-lua-plugin/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Make sure to have a valid Kong declarative configuration file kong.yaml in the folder specified for KONG_CONFIG.
 ## For deployment of a simple lab testing environment, you can deploy the example configuration provided

--- a/deployment/docker-compose/kong-lua-plugin/docker-compose.yaml
+++ b/deployment/docker-compose/kong-lua-plugin/docker-compose.yaml
@@ -106,14 +106,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/kong/.env
+++ b/deployment/docker-compose/kong/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Make sure to have a valid Kong declarative configuration file kong.yaml in the folder specified for KONG_CONFIG.
 ## For deployment of a simple lab testing environment, you can deploy the example configuration provided

--- a/deployment/docker-compose/kong/docker-compose.yaml
+++ b/deployment/docker-compose/kong/docker-compose.yaml
@@ -106,14 +106,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/nginx-proxy-manager-centrally-managed/.env
+++ b/deployment/docker-compose/nginx-proxy-manager-centrally-managed/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 # Volume mounts for NGINX Proxy Manager have been moved here as well allowing configuration via .env file 
 NPM_DATA=./data

--- a/deployment/docker-compose/nginx-proxy-manager-centrally-managed/docker-compose.yaml
+++ b/deployment/docker-compose/nginx-proxy-manager-centrally-managed/docker-compose.yaml
@@ -103,14 +103,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/nginx-proxy-manager/.env
+++ b/deployment/docker-compose/nginx-proxy-manager/.env
@@ -21,6 +21,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 # Volume mounts for NGINX Proxy Manager have been moved here as well allowing configuration via .env file 
 NPM_DATA=./data

--- a/deployment/docker-compose/nginx-proxy-manager/docker-compose.yaml
+++ b/deployment/docker-compose/nginx-proxy-manager/docker-compose.yaml
@@ -106,14 +106,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/nginx-unified/.env
+++ b/deployment/docker-compose/nginx-unified/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Make sure to have a valid NGINX configuration file default.conf in the folder specified for NGINX_CONFIG.
 ## For deployment of a simple lab testing environment, you can deploy the example configuration provided

--- a/deployment/docker-compose/nginx-unified/docker-compose.yaml
+++ b/deployment/docker-compose/nginx-unified/docker-compose.yaml
@@ -96,14 +96,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/nginx/.env
+++ b/deployment/docker-compose/nginx/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Make sure to have a valid NGINX configuration file default.conf in the folder specified for NGINX_CONFIG.
 ## For deployment of a simple lab testing environment, you can deploy the example configuration provided

--- a/deployment/docker-compose/nginx/docker-compose.yaml
+++ b/deployment/docker-compose/nginx/docker-compose.yaml
@@ -108,14 +108,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/docker-compose/swag/.env
+++ b/deployment/docker-compose/swag/.env
@@ -23,6 +23,7 @@ APPSEC_DB_PASSWORD=pass
 APPSEC_DB_USER=postgres
 APPSEC_DB_HOST=appsec-db
 APPSEC_POSTGRES_STORAGE=./appsec-postgres-data
+APPSEC_POSTGRES_VERSION=18
 
 ## Most relevant SWAG parameters have been moved here as well allowing configuration via .env file 
 SWAG_CONFIG=./swag-config

--- a/deployment/docker-compose/swag/docker-compose.yaml
+++ b/deployment/docker-compose/swag/docker-compose.yaml
@@ -117,14 +117,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${APPSEC_POSTGRES_VERSION}
     container_name: appsec-db
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${APPSEC_DB_PASSWORD}
       - POSTGRES_USER=${APPSEC_DB_USER} 
     volumes:
-      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${APPSEC_POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
   juiceshop-backend:

--- a/deployment/nginx/.env
+++ b/deployment/nginx/.env
@@ -15,6 +15,7 @@ USER_EMAIL=user@email.com
 DB_PASSWORD=pass
 DB_USER=postgres
 DB_HOST=appsec-db
+POSTGRES_VERSION=18
 POSTGRES_STORAGE=./postgres-data
 NGINX_CONF_DIR=./nginx-proxy-config
 

--- a/deployment/nginx/docker-compose.yaml
+++ b/deployment/nginx/docker-compose.yaml
@@ -81,14 +81,14 @@ services:
   appsec-db:
     profiles:
       - standalone
-    image: postgres
+    image: postgres:${POSTGRES_VERSION}
     container_name: appsec-db
     restart: always
     environment:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
       - POSTGRES_USER=${DB_USER} 
     volumes:
-      - ${POSTGRES_STORAGE}:/var/lib/postgresql/data
+      - ${POSTGRES_STORAGE}:/var/lib/postgresql
 
 ## example juice-shop backend container (vulnerable webserver, USE ONLY FOR TESTING AND IN LAB ENV)
 ##


### PR DESCRIPTION
- Change PostgreSQL volume mount from /var/lib/postgresql/data to /var/lib/postgresql This allows PostgreSQL to manage the data directory structure internally

- Add PostgreSQL version configuration variable to all docker-compose files:
  * POSTGRES_VERSION for deployment/nginx
  * APPSEC_POSTGRES_VERSION for all deployment/docker-compose variants

- Update PostgreSQL image tag to use version variable (set to version 18) Changed from 'postgres' to 'postgres:' or 'postgres:'

- Add PostgreSQL version variable to all .env files with default value of 18