### PR TITLE
Reduce mainloop CPU usage while idle

### DIFF
--- a/core/mainloop/coroutine.cc
+++ b/core/mainloop/coroutine.cc
@@ -43,6 +43,12 @@ RoutineWrapper::isActive() const
 }
 
 bool
+RoutineWrapper::isHalted() const
+{
+    return is_halt;
+}
+
+bool
 RoutineWrapper::shouldRun(const I_MainLoop::RoutineType &limit) const
 {
     return !is_halt && pri<=limit;

--- a/core/mainloop/coroutine.h
+++ b/core/mainloop/coroutine.h
@@ -41,6 +41,7 @@ public:
     bool isPrimary() { return is_primary; }
     const std::string & getRoutineName() const { return routine_name; }
     bool isActive() const;
+    bool isHalted() const;
     bool shouldRun(const I_MainLoop::RoutineType &limit) const;
     void run();
     void yield();

--- a/core/mainloop/mainloop.cc
+++ b/core/mainloop/mainloop.cc
@@ -14,13 +14,18 @@
 #include "mainloop.h"
 
 #include <cstddef>
+#include <cerrno>
+#include <climits>
+#include <cstdint>
 #include <memory>
 #include <system_error>
 #include <map>
+#include <set>
 #include <sstream>
 #include <poll.h>
 #include <unistd.h>
 #include <functional>
+#include <vector>
 
 #include "config.h"
 #include "coroutine.h"
@@ -43,6 +48,8 @@ class MainloopStop {};
 class MainloopComponent::Impl : Singleton::Provide<I_MainLoop>::From<MainloopComponent>
 {
     using RoutineMap = map<RoutineID, RoutineWrapper>;
+    using FileRoutineMap = map<RoutineID, int>;
+    using WakeupMap = map<RoutineID, chrono::microseconds>;
 
 public:
     void run() override;
@@ -145,6 +152,12 @@ public:
 private:
     void reportStartupEvent();
     void stop(const RoutineMap::iterator &iter);
+    bool canWaitForEvents(bool has_primary_routines, chrono::microseconds current_time) const;
+    chrono::microseconds getIdleWaitDuration(
+        chrono::microseconds current_time,
+        chrono::microseconds maximum_wait
+    ) const;
+    void waitForEvents(chrono::microseconds timeout);
     uint32_t getCurrentTimeSlice(uint32_t current_stress, int idle_time_slice, int busy_time_slice);
     RoutineID getNextID();
 
@@ -165,6 +178,10 @@ private:
     I_Environment *env = nullptr;
 
     RoutineMap routines;
+    FileRoutineMap file_routines;
+    WakeupMap routine_wakeup_times;
+    set<RoutineID> active_file_callbacks;
+    set<RoutineID> terminal_file_routines;
     RoutineMap::iterator curr_iter = routines.end();
     RoutineID next_routine_id = 0;
 
@@ -197,6 +214,114 @@ static I_MainLoop::RoutineType rounds[] = {
     I_MainLoop::RoutineType::RealTime,
     I_MainLoop::RoutineType::Offline,
 };
+
+bool
+MainloopComponent::Impl::canWaitForEvents(
+    bool has_primary_routines,
+    chrono::microseconds current_time) const
+{
+    if (!has_primary_routines) return false;
+
+    bool has_waiting_routine = false;
+    for (const auto &routine : routines) {
+        if (!routine.second.isActive()) continue;
+        if (routine.second.isHalted()) {
+            has_waiting_routine = true;
+            continue;
+        }
+
+        auto wakeup = routine_wakeup_times.find(routine.first);
+        if (wakeup != routine_wakeup_times.end() && current_time < wakeup->second) {
+            has_waiting_routine = true;
+            continue;
+        }
+
+        if (
+            file_routines.find(routine.first) != file_routines.end() &&
+            active_file_callbacks.find(routine.first) == active_file_callbacks.end()
+        ) {
+            has_waiting_routine = true;
+            continue;
+        }
+
+        return false;
+    }
+
+    return has_waiting_routine;
+}
+
+chrono::microseconds
+MainloopComponent::Impl::getIdleWaitDuration(
+    chrono::microseconds current_time,
+    chrono::microseconds maximum_wait) const
+{
+    chrono::microseconds wait_time = maximum_wait;
+    for (const auto &wakeup : routine_wakeup_times) {
+        auto routine = routines.find(wakeup.first);
+        if (
+            routine == routines.end() ||
+            !routine->second.isActive() ||
+            routine->second.isHalted()
+        ) {
+            continue;
+        }
+
+        if (wakeup.second <= current_time) return chrono::microseconds::zero();
+        wait_time = min(wait_time, wakeup.second - current_time);
+    }
+    return wait_time;
+}
+
+void
+MainloopComponent::Impl::waitForEvents(chrono::microseconds timeout)
+{
+    if (timeout <= chrono::microseconds::zero()) return;
+
+    vector<struct pollfd> poll_fds;
+    vector<RoutineID> poll_ids;
+    poll_fds.reserve(file_routines.size());
+    poll_ids.reserve(file_routines.size());
+    for (const auto &file_routine : file_routines) {
+        auto routine = routines.find(file_routine.first);
+        if (
+            routine == routines.end() ||
+            !routine->second.isActive() ||
+            routine->second.isHalted() ||
+            terminal_file_routines.find(file_routine.first) != terminal_file_routines.end() ||
+            active_file_callbacks.find(file_routine.first) != active_file_callbacks.end()
+        ) {
+            continue;
+        }
+
+        struct pollfd descriptor;
+        descriptor.fd = file_routine.second;
+        descriptor.events = POLLIN;
+        descriptor.revents = 0;
+        poll_fds.push_back(descriptor);
+        poll_ids.push_back(file_routine.first);
+    }
+
+    auto timeout_count = timeout.count();
+    int timeout_in_msec = timeout_count >= static_cast<int64_t>(INT_MAX) * 1000
+        ? INT_MAX
+        : static_cast<int>((timeout_count + 999) / 1000);
+    int rc = poll(poll_fds.data(), poll_fds.size(), timeout_in_msec);
+    if (rc < 0 && errno != EINTR) {
+        dbgWarning(D_MAINLOOP)
+            << "Failed to wait for mainloop events: "
+            << error_code(errno, generic_category()).message();
+    } else if (rc > 0) {
+        for (size_t i = 0; i < poll_fds.size(); i++) {
+            if ((poll_fds[i].revents & POLLIN) != 0) {
+                terminal_file_routines.erase(poll_ids[i]);
+            } else if ((poll_fds[i].revents & (POLLHUP | POLLERR | POLLNVAL)) != 0) {
+                // A terminal-only event stays ready forever. Stop including it in the
+                // central wait so an abandoned descriptor cannot spin the scheduler.
+                terminal_file_routines.insert(poll_ids[i]);
+            }
+        }
+    }
+}
 
 void
 MainloopComponent::Impl::reportStartupEvent()
@@ -266,6 +391,8 @@ MainloopComponent::Impl::run()
     int idle_time_slice = getConfigurationWithDefault<int>(1500, "Mainloop", "Idle routine time slice");
     int busy_time_slice = getConfigurationWithDefault<int>(100, "Mainloop", "Busy routine time slice");
     int exceed_warning_slice = getConfigurationWithDefault(100, "Mainloop", "Exceed Warning");
+    uint idle_event_wait_timeout =
+        getConfigurationWithDefault<uint>(100, "Mainloop", "Idle event wait timeout in msec");
 
     while (has_primary_routines) {
         mainloop_event.setStressValue(current_stress);
@@ -273,6 +400,8 @@ MainloopComponent::Impl::run()
             idle_time_slice = getConfigurationWithDefault<int>(1500, "Mainloop", "Idle routine time slice");
             busy_time_slice = getConfigurationWithDefault<int>(100, "Mainloop", "Busy routine time slice");
             exceed_warning_slice = getConfigurationWithDefault(100, "Mainloop", "Exceed Warning");
+            idle_event_wait_timeout =
+                getConfigurationWithDefault<uint>(100, "Mainloop", "Idle event wait timeout in msec");
             reload_configuration = false;
         }
         int time_slice_to_use = getCurrentTimeSlice(current_stress, idle_time_slice, busy_time_slice);
@@ -288,13 +417,21 @@ MainloopComponent::Impl::run()
                 break;
             }
             if (!curr_iter->second.isActive()) {
+                file_routines.erase(curr_iter->first);
+                routine_wakeup_times.erase(curr_iter->first);
+                active_file_callbacks.erase(curr_iter->first);
+                terminal_file_routines.erase(curr_iter->first);
                 curr_iter = routines.erase(curr_iter);
                 continue;
             }
 
             if (curr_iter->second.isPrimary()) has_primary_routines = true;
 
-            if (curr_iter->second.shouldRun(rounds[round])) {
+            auto wakeup = routine_wakeup_times.find(curr_iter->first);
+            bool is_waiting =
+                wakeup != routine_wakeup_times.end() &&
+                getTimer()->getMonotonicTime() < wakeup->second;
+            if (!is_waiting && curr_iter->second.shouldRun(rounds[round])) {
                 // Set the time upon which `hasAdditionalTime` will yield.
                 stop_time = getTimer()->getMonotonicTime() + basic_time_slice;
                 dbgTrace(D_MAINLOOP) <<
@@ -351,12 +488,24 @@ MainloopComponent::Impl::run()
 
         uint64_t signed_sleep_time = 0;
         chrono::microseconds current_time = getTimer()->getMonotonicTime();
-        if (start_time + basic_time_slice > current_time) {
+        bool should_wait_for_events =
+            idle_event_wait_timeout > 0 &&
+            current_stress == 0 &&
+            canWaitForEvents(has_primary_routines, current_time);
+        if (should_wait_for_events) {
+            auto maximum_wait = chrono::duration_cast<chrono::microseconds>(
+                chrono::milliseconds(idle_event_wait_timeout)
+            );
+            auto wait_time = getIdleWaitDuration(current_time, maximum_wait);
+            waitForEvents(wait_time);
+            auto after_wait = getTimer()->getMonotonicTime();
+            if (after_wait > current_time) signed_sleep_time = (after_wait - current_time).count();
+        } else if (start_time + basic_time_slice > current_time) {
             chrono::microseconds sleep_time = start_time + basic_time_slice - current_time;
             signed_sleep_time = sleep_time.count();
-            sleep_count += signed_sleep_time;
             usleep(signed_sleep_time);
         }
+        sleep_count += signed_sleep_time;
 
         mainloop_event.setSleepTime(signed_sleep_time);
         mainloop_event.notify();
@@ -377,6 +526,10 @@ MainloopComponent::Impl::run()
     dbgInfo(D_MAINLOOP) << "Mainloop ended - stopping all routines";
     stopAll();
     routines.clear();
+    file_routines.clear();
+    routine_wakeup_times.clear();
+    active_file_callbacks.clear();
+    terminal_file_routines.clear();
 }
 
 string
@@ -500,7 +653,16 @@ MainloopComponent::Impl::addFileRoutine(
             s_poll.revents = 0;
             int rc = poll(&s_poll, 1, 0);
             if (rc > 0 && (s_poll.revents & POLLIN) != 0) {
-                func();
+                RoutineID routine_id = curr_iter->first;
+                terminal_file_routines.erase(routine_id);
+                active_file_callbacks.insert(routine_id);
+                try {
+                    func();
+                } catch (...) {
+                    active_file_callbacks.erase(routine_id);
+                    throw;
+                }
+                active_file_callbacks.erase(routine_id);
                 if (priority == I_MainLoop::RoutineType::RealTime) {
                     if (s_poll.revents & POLLHUP) {
                         updateCurrentStress(false);
@@ -515,7 +677,9 @@ MainloopComponent::Impl::addFileRoutine(
         }
     };
 
-    return addOneTimeRoutine(priority, func_wrapper, routine_name, is_primary);
+    RoutineID id = addOneTimeRoutine(priority, func_wrapper, routine_name, is_primary);
+    file_routines.emplace(id, fd);
+    return id;
 }
 
 bool
@@ -550,14 +714,20 @@ MainloopComponent::Impl::yield(bool force)
 void
 MainloopComponent::Impl::yield(chrono::microseconds time)
 {
+    if (time < chrono::microseconds::zero()) return;
     if (time == chrono::microseconds::zero()) {
         yield(true);
         return;
     }
-    chrono::microseconds restart_time = getTimer()->getMonotonicTime() + time;
-    while (getTimer()->getMonotonicTime() < restart_time) {
-        yield(true);
+    if (curr_iter == routines.end()) {
+        dbgAssertOpt(curr_iter != routines.end()) << alert << "Calling 'yield' without a running current routine";
+        return;
     }
+
+    RoutineID routine_id = curr_iter->first;
+    routine_wakeup_times[routine_id] = getTimer()->getMonotonicTime() + time;
+    yield(true);
+    routine_wakeup_times.erase(routine_id);
 }
 
 void
@@ -704,6 +874,7 @@ MainloopComponent::preload()
 {
     registerExpectedConfiguration<int>("Mainloop", "Idle routine time slice");
     registerExpectedConfiguration<int>("Mainloop", "Busy routine time slice");
+    registerExpectedConfiguration<uint>("Mainloop", "Idle event wait timeout in msec");
     registerExpectedConfiguration<uint>("Mainloop", "metric reporting interval");
     registerExpectedConfiguration<uint>("Mainloop", "Exceed Warning");
     registerExpectedConfiguration<bool>("Mainloop", "Report Startup Event");

--- a/core/mainloop/mainloop.cc
+++ b/core/mainloop/mainloop.cc
@@ -663,6 +663,9 @@ MainloopComponent::Impl::addFileRoutine(
                     throw;
                 }
                 active_file_callbacks.erase(routine_id);
+                if ((s_poll.revents & (POLLHUP | POLLERR | POLLNVAL)) != 0) {
+                    terminal_file_routines.insert(routine_id);
+                }
                 if (priority == I_MainLoop::RoutineType::RealTime) {
                     if (s_poll.revents & POLLHUP) {
                         updateCurrentStress(false);

--- a/core/mainloop/mainloop_ut/mainloop_ut.cc
+++ b/core/mainloop/mainloop_ut/mainloop_ut.cc
@@ -3,6 +3,7 @@
 
 #include <fcntl.h>
 #include <chrono>
+#include <thread>
 
 #include "cptest.h"
 #include "config.h"
@@ -432,6 +433,215 @@ TEST_F(MainloopTest, call_file_cb)
 
     mainloop->run();
     EXPECT_EQ(4, num_called);
+}
+
+TEST_F(MainloopTest, timed_yield_does_not_spin_the_scheduler)
+{
+    size_t monotonic_reads = 0;
+    auto start_time = steady_clock::now();
+    EXPECT_CALL(mock_time, getMonotonicTime()).WillRepeatedly(
+        InvokeWithoutArgs(
+            [&monotonic_reads, start_time] () {
+                monotonic_reads++;
+                return duration_cast<microseconds>(steady_clock::now() - start_time);
+            }
+        )
+    );
+
+    mainloop->addOneTimeRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        [this] () {
+            mainloop->yield(milliseconds(250));
+            mainloop->stop();
+        },
+        "timed idle routine",
+        true
+    );
+
+    mainloop->run();
+    EXPECT_LT(monotonic_reads, 100u) << "Monotonic clock was read " << monotonic_reads << " times";
+}
+
+TEST_F(MainloopTest, idle_file_routine_wait_is_interrupted_by_readiness)
+{
+    mainloop_comp.preload();
+    setConfiguration<uint>(
+        1000,
+        string("Mainloop"),
+        string("Idle event wait timeout in msec")
+    );
+
+    size_t monotonic_reads = 0;
+    auto start_time = steady_clock::now();
+    EXPECT_CALL(mock_time, getMonotonicTime()).WillRepeatedly(
+        InvokeWithoutArgs(
+            [&monotonic_reads, start_time] () {
+                monotonic_reads++;
+                return duration_cast<microseconds>(steady_clock::now() - start_time);
+            }
+        )
+    );
+
+    int pipe_fds[2];
+    ASSERT_EQ(0, pipe(pipe_fds));
+    auto close_pipe = make_scope_exit(
+        [&pipe_fds] () {
+            close(pipe_fds[0]);
+            close(pipe_fds[1]);
+        }
+    );
+
+    thread writer(
+        [&pipe_fds] () {
+            this_thread::sleep_for(milliseconds(250));
+            char byte = 'a';
+            EXPECT_EQ(1, write(pipe_fds[1], &byte, 1));
+        }
+    );
+    auto join_writer = make_scope_exit([&writer] () { writer.join(); });
+
+    mainloop->addFileRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        pipe_fds[0],
+        [&pipe_fds, this] () {
+            char byte;
+            ASSERT_EQ(1, read(pipe_fds[0], &byte, 1));
+            mainloop->stop();
+        },
+        "idle pipe reader",
+        true
+    );
+
+    mainloop->run();
+    auto elapsed = duration_cast<milliseconds>(steady_clock::now() - start_time);
+    EXPECT_LT(monotonic_reads, 100u) << "Monotonic clock was read " << monotonic_reads << " times";
+    EXPECT_LT(elapsed.count(), 500) << "File readiness was handled after " << elapsed.count() << " ms";
+}
+
+TEST_F(MainloopTest, yielding_file_callback_remains_runnable)
+{
+    mainloop_comp.preload();
+    setConfiguration<uint>(
+        1000,
+        string("Mainloop"),
+        string("Idle event wait timeout in msec")
+    );
+
+    int pipe_fds[2];
+    ASSERT_EQ(0, pipe(pipe_fds));
+    auto close_pipe = make_scope_exit(
+        [&pipe_fds] () {
+            close(pipe_fds[0]);
+            close(pipe_fds[1]);
+        }
+    );
+    char byte = 'a';
+    ASSERT_EQ(1, write(pipe_fds[1], &byte, 1));
+
+    mainloop->addFileRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        pipe_fds[0],
+        [&pipe_fds, this] () {
+            char byte;
+            ASSERT_EQ(1, read(pipe_fds[0], &byte, 1));
+            mainloop->yield(true);
+            mainloop->stop();
+        },
+        "yielding pipe reader",
+        true
+    );
+
+    auto start_time = steady_clock::now();
+    mainloop->run();
+    auto elapsed = duration_cast<milliseconds>(steady_clock::now() - start_time);
+    EXPECT_LT(elapsed.count(), 250) << "File callback resumed after " << elapsed.count() << " ms";
+}
+
+TEST_F(MainloopTest, timed_yield_in_file_callback_suspends_descriptor_polling)
+{
+    mainloop_comp.preload();
+    setConfiguration<uint>(
+        1000,
+        string("Mainloop"),
+        string("Idle event wait timeout in msec")
+    );
+
+    size_t monotonic_reads = 0;
+    auto start_time = steady_clock::now();
+    EXPECT_CALL(mock_time, getMonotonicTime()).WillRepeatedly(
+        InvokeWithoutArgs(
+            [&monotonic_reads, start_time] () {
+                monotonic_reads++;
+                return duration_cast<microseconds>(steady_clock::now() - start_time);
+            }
+        )
+    );
+
+    int pipe_fds[2];
+    ASSERT_EQ(0, pipe(pipe_fds));
+    auto close_pipe = make_scope_exit(
+        [&pipe_fds] () {
+            close(pipe_fds[0]);
+            close(pipe_fds[1]);
+        }
+    );
+    const char bytes[] = { 'a', 'b' };
+    ASSERT_EQ(2, write(pipe_fds[1], bytes, sizeof(bytes)));
+
+    mainloop->addFileRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        pipe_fds[0],
+        [&pipe_fds, this] () {
+            char byte;
+            ASSERT_EQ(1, read(pipe_fds[0], &byte, 1));
+            mainloop->yield(milliseconds(250));
+            mainloop->stop();
+        },
+        "timed yielding pipe reader",
+        true
+    );
+
+    mainloop->run();
+    EXPECT_LT(monotonic_reads, 100u) << "Monotonic clock was read " << monotonic_reads << " times";
+}
+
+TEST_F(MainloopTest, terminal_file_descriptor_does_not_spin_the_scheduler)
+{
+    size_t monotonic_reads = 0;
+    auto start_time = steady_clock::now();
+    EXPECT_CALL(mock_time, getMonotonicTime()).WillRepeatedly(
+        InvokeWithoutArgs(
+            [&monotonic_reads, start_time] () {
+                monotonic_reads++;
+                return duration_cast<microseconds>(steady_clock::now() - start_time);
+            }
+        )
+    );
+
+    int pipe_fds[2];
+    ASSERT_EQ(0, pipe(pipe_fds));
+    close(pipe_fds[1]);
+    auto close_reader = make_scope_exit([&pipe_fds] () { close(pipe_fds[0]); });
+
+    mainloop->addFileRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        pipe_fds[0],
+        [] () {},
+        "closed pipe reader",
+        true
+    );
+    mainloop->addOneTimeRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        [this] () {
+            mainloop->yield(milliseconds(250));
+            mainloop->stopAll();
+        },
+        "terminal descriptor timeout",
+        false
+    );
+
+    mainloop->run();
+    EXPECT_LT(monotonic_reads, 100u) << "Monotonic clock was read " << monotonic_reads << " times";
 }
 
 TEST_F(MainloopTest, stop_while_routines_are_running)

--- a/core/mainloop/mainloop_ut/mainloop_ut.cc
+++ b/core/mainloop/mainloop_ut/mainloop_ut.cc
@@ -2,6 +2,8 @@
 #include "mainloop.h"
 
 #include <fcntl.h>
+#include <poll.h>
+#include <sys/socket.h>
 #include <chrono>
 #include <thread>
 
@@ -605,7 +607,60 @@ TEST_F(MainloopTest, timed_yield_in_file_callback_suspends_descriptor_polling)
     EXPECT_LT(monotonic_reads, 100u) << "Monotonic clock was read " << monotonic_reads << " times";
 }
 
-TEST_F(MainloopTest, terminal_file_descriptor_does_not_spin_the_scheduler)
+TEST_F(MainloopTest, readable_eof_does_not_spin_the_scheduler)
+{
+    size_t monotonic_reads = 0;
+    auto start_time = steady_clock::now();
+    EXPECT_CALL(mock_time, getMonotonicTime()).WillRepeatedly(
+        InvokeWithoutArgs(
+            [&monotonic_reads, start_time] () {
+                monotonic_reads++;
+                return duration_cast<microseconds>(steady_clock::now() - start_time);
+            }
+        )
+    );
+
+    int socket_fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
+    close(socket_fds[1]);
+    auto close_reader = make_scope_exit([&socket_fds] () { close(socket_fds[0]); });
+
+    struct pollfd readiness;
+    readiness.fd = socket_fds[0];
+    readiness.events = POLLIN;
+    readiness.revents = 0;
+    ASSERT_EQ(1, poll(&readiness, 1, 0));
+    ASSERT_NE(0, readiness.revents & POLLIN);
+    ASSERT_NE(0, readiness.revents & POLLHUP);
+
+    size_t callback_count = 0;
+    mainloop->addFileRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        socket_fds[0],
+        [&socket_fds, &callback_count] () {
+            char byte;
+            EXPECT_EQ(0, read(socket_fds[0], &byte, 1));
+            callback_count++;
+        },
+        "closed socket reader",
+        true
+    );
+    mainloop->addOneTimeRoutine(
+        I_MainLoop::RoutineType::RealTime,
+        [this] () {
+            mainloop->yield(milliseconds(250));
+            mainloop->stopAll();
+        },
+        "terminal descriptor timeout",
+        false
+    );
+
+    mainloop->run();
+    EXPECT_LT(monotonic_reads, 100u) << "Monotonic clock was read " << monotonic_reads << " times";
+    EXPECT_LT(callback_count, 10u) << "EOF callback ran " << callback_count << " times";
+}
+
+TEST_F(MainloopTest, terminal_only_event_does_not_spin_the_scheduler)
 {
     size_t monotonic_reads = 0;
     auto start_time = steady_clock::now();


### PR DESCRIPTION
## Summary

Replace the mainloop's fixed-rate idle scan with an event-driven wait when every active coroutine is known to be waiting.

- Store timed-yield deadlines instead of repeatedly resuming a coroutine only to check the clock and yield again.
- Poll registered file descriptors together, with readiness interrupting the idle wait immediately.
- Keep the existing scheduler cadence whenever a coroutine is runnable or the service reports load.
- Cap idle waits at a configurable 100 ms by default, and shorten them to the nearest timed deadline.
- Back off terminal descriptors, including readable EOF reported as `POLLIN|POLLHUP`, so they cannot create a new hot loop.

## Motivation

This addresses the idle CPU behavior reported in #119:

- The original report showed roughly 5% CPU **per nano service**, including four HTTP transaction handlers, with no traffic.
- [The behavior remained on 1.1.7 after updating and recompiling](https://github.com/openappsec/openappsec/issues/119#issuecomment-2032519795).
- [A second user reproduced it on 1.1.7 with both Docker/NPM and a direct host install](https://github.com/openappsec/openappsec/issues/119#issuecomment-2033732354).
- [Another idle load balancer stayed at roughly 25% CPU](https://github.com/openappsec/openappsec/issues/119#issuecomment-2046973652).
- [A post-closure report still measured 30% idle CPU on 1.1.14](https://github.com/openappsec/openappsec/issues/119#issuecomment-2223646677).

The current mainloop performs a nonblocking `poll(fd, 1, 0)` in every file routine and otherwise sleeps only until the next 1,500 microsecond time slice. Timed `yield(duration)` also loops through the scheduler while checking the monotonic clock. With multiple nano services and one handler per NGINX worker, that fixed polling cost is multiplied even when no HTTP traffic exists.

## Measurements

Unit-level scheduler regression on the same machine and build configuration:

| 250 ms idle scenario | current `main` | this change | reduction |
| --- | ---: | ---: | ---: |
| timed `yield()` monotonic-clock reads | 804 | 22 | 97.3% |
| file routine waiting for pipe readiness | 643 | 12 | 98.1% |

Packaged Docker agents were also run side by side with identical 2 CPU / 2 GiB limits and no HTTP traffic. CPU was measured from `/proc/<pid>/stat` over two independent 30-second windows, targeting the orchestration and attachment-registrator processes so entrypoint helper scripts did not contaminate the result:

| Image | window 1 | window 2 |
| --- | ---: | ---: |
| official `ghcr.io/openappsec/agent:1.1.34` | 1.80% | 1.80% |
| patched current-main build | 0.47% | 0.50% |

That is a 72-74% reduction for the two live agent services. The isolated scheduler tests show the larger reduction expected in services whose idle work is dominated by the mainloop.

## Correctness safeguards

The central wait is used only when all active routines are halted, waiting for a deadline, or idle file routines. It is bypassed when stress is nonzero or any arbitrary cooperative routine remains runnable. File callbacks that yield remain runnable, while a timed yield inside a file callback temporarily removes that descriptor from the central poll.

New tests cover:

- timed yields without scheduler spinning;
- prompt wakeup on descriptor readiness, including a 250 ms writer under a 1,000 ms wait cap;
- a file callback using ordinary cooperative `yield(true)`;
- a timed yield inside a still-readable file callback;
- readable EOF (`POLLIN|POLLHUP`) and terminal-only descriptor events without an idle hot loop.

`mainloop_ut`: 29/29 tests pass. The production core library links successfully, and a packaged patched agent was built and exercised for the comparison above.

Addresses #119.
