### PR TITLE
Update security contact to security-alert@checkpoint.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This guide will provide an overview of the various contribution options' guideli
 
 ## Reporting security vulnerabilities
 
-If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at [security-alert@openappsec.io](mailto:security-alert@openappsec.io). We'll send a confirmation email to acknowledge your report within 24 hours and send an additional email when we've identified the issue positively or negatively.
+If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at [security-alert@checkpoint.com](mailto:security-alert@checkpoint.com). We'll send a confirmation email to acknowledge your report within 24 hours and send an additional email when we've identified the issue positively or negatively.
 
 An internal process will be activated upon determining the validity of a reported security vulnerability, which will end with releasing a fix and deciding on the appropriate disclosure actions. The reporter of the issue will receive updates on this process' progress.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ open-appsec code was audited by an independent third party in September-October 
 See the [full report](https://github.com/openappsec/openappsec/blob/main/LEXFO-CHP20221014-Report-Code_audit-OPEN-APPSEC-v1.2.pdf).
 
 ### Reporting security vulnerabilities
-If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at security-alert@openappsec.io. We'll send a confirmation email to acknowledge your report within 24 hours, and we'll send an additional email when we've identified the issue positively or negatively.
+If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at security-alert@checkpoint.com. We'll send a confirmation email to acknowledge your report within 24 hours, and we'll send an additional email when we've identified the issue positively or negatively.
 
 
 # License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at [security-alert@openappsec.io](mailto:security-alert@openappsec.io). We'll send a confirmation email to acknowledge your report within 24 hours, and we'll send an additional email when we've identified the issue positively or negatively.
+If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at [security-alert@checkpoint.com](mailto:security-alert@checkpoint.com). We'll send a confirmation email to acknowledge your report within 24 hours, and we'll send an additional email when we've identified the issue positively or negatively.
 
 A process will be activated upon determining the validity of a reported security vulnerability, which will end with releasing a fix and deciding on the applicable disclosure actions. The reporter of the issue will receive updates of this process' progress.

--- a/contrib/CONTRIBUTING.md
+++ b/contrib/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This guide will provide an overview of the various contribution options' guideli
 
 ## Reporting security vulnerabilities
 
-If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at [security-alert@openappsec.io](mailto:security-alert@openappsec.io). We'll send a confirmation email to acknowledge your report within 24 hours and send an additional email when we've identified the issue positively or negatively.
+If you've found a vulnerability or a potential vulnerability in open-appsec please let us know at [security-alert@checkpoint.com](mailto:security-alert@checkpoint.com). We'll send a confirmation email to acknowledge your report within 24 hours and send an additional email when we've identified the issue positively or negatively.
 
 An internal process will be activated upon determining the validity of a reported security vulnerability, which will end with releasing a fix and deciding on the appropriate disclosure actions. The reporter of the issue will receive updates on this process' progress.
 


### PR DESCRIPTION
Replaces the `security-alert@openappsec.io` alias with `security-alert@checkpoint.com` as the contact address for reporting security vulnerabilities.

**Why:** the `openappsec.io` alias can't be reliably forwarded — mail sent to it gets rewritten to the general `info@openappsec.io` mailbox, so forwarding rules targeting `security-alert@openappsec.io` don't work. Vulnerability reports sent to the old address may therefore not reach the security team.

**Changed in all four places the address appears:**

| File | Context |
|---|---|
| `README.md` | "Reporting security vulnerabilities" section shown on the repo landing page |
| `CONTRIBUTING.md` | "Reporting security vulnerabilities" section |
| `SECURITY.md` | GitHub security policy — backs the Security tab and the "Report a vulnerability" flow |
| `contrib/CONTRIBUTING.md` | Duplicate copy of the contributing guide |

Text is otherwise unchanged; only the address and its `mailto:` link are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
