### PR TITLE
docs: add missing Brotli and zlib to build dependency list (fixes #430)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Before compiling the services, you'll need to ensure the latest development vers
 * Boost
 * OpenSSL
 * PCRE2
+* Brotli
+* zlib
 * libxml2
 * GTest
 * GMock
@@ -107,7 +109,7 @@ An example of installing the packages on Alpine:
 
 ```bash
  $ apk update
- $ apk add boost-dev openssl-dev pcre2-dev libxml2-dev gtest-dev curl-dev hiredis-dev redis libmaxminddb-dev yq
+ $ apk add boost-dev openssl-dev pcre2-dev libxml2-dev gtest-dev curl-dev hiredis-dev redis libmaxminddb-dev yq brotli-dev zlib-dev
 ```
 
 ## Compiling and packaging the agent code


### PR DESCRIPTION
## What

Adds **Brotli** and **zlib** to the build dependency list in `README.md` — both to the bullet list and to the Alpine `apk add` example.

## Why

`CMakeLists.txt` hard-requires five packages, two of which were undocumented:

| Line | Package | Was in README? |
|---|---|---|
| 15 | `Boost` | yes |
| 16 | `ZLIB` | **no** |
| 17 | `GTest` | yes |
| 18 | `PkgConfig` | n/a |
| 19 | `Brotli` | **no** |

So following the documented compile steps fails at the cmake stage with:

```
CMake Error at cmake/FindBrotli.cmake:210 (find_package_handle_standard_args):
  Could NOT find Brotli (missing: Brotli_INCLUDE_DIR)
Call Stack (most recent call first):
  CMakeLists.txt:19 (find_package)
```

zlib was likely being pulled in transitively on Alpine, which is why only Brotli was reported — but it is a `REQUIRED` package that we never document, so it is listed here too.

Reported by @NoamWeiss in #430.

Fixes #430

## Not included, deliberately

Two related items were left out of this PR:

1. **A Debian/Ubuntu install example.** The README only offers an Alpine example, and the reporter hit this on Ubuntu — that is arguably the deeper problem. I drafted an `apt-get` equivalent but have not built with it, so it isn't included here rather than shipping unverified install instructions. Worth a follow-up once someone runs it on a clean Ubuntu container.

2. **`cmake_minimum_required (VERSION 2.8.4)` at `CMakeLists.txt:1`**, which fails outright on CMake 4.x (Ubuntu 26.04, Arch, nixpkgs unstable). That is a code fix, not a docs fix, and is tracked separately in #432 / #143.

Also worth checking: the docs-site page `deployment-and-upgrade/build-open-appsec-based-on-source-code` may duplicate this dependency list and need the same edit.

## Test plan

Docs-only change; no build impact. Verified the two edits are the only diff against `main`.
